### PR TITLE
fix: args for Jython script should not be ignored

### DIFF
--- a/JythonCli.java
+++ b/JythonCli.java
@@ -95,7 +95,6 @@ public class JythonCli {
             if (arg.endsWith(".py")) {
                 scriptFilename = arg;
                 jythonArgs.add(arg);
-                break;
             } else if ("--cli-debug".equals(arg)) {
                 debug = true;
             } else {

--- a/JythonCli.java
+++ b/JythonCli.java
@@ -91,8 +91,9 @@ public class JythonCli {
             System.exit(1);
         }
 
+        scriptFilename = "";
         for (String arg : args) {
-            if (arg.endsWith(".py")) {
+            if (scriptFilename.isEmpty() && arg.endsWith(".py")) {
                 scriptFilename = arg;
                 jythonArgs.add(arg);
             } else if ("--cli-debug".equals(arg)) {

--- a/JythonCli.java
+++ b/JythonCli.java
@@ -91,9 +91,8 @@ public class JythonCli {
             System.exit(1);
         }
 
-        scriptFilename = "";
         for (String arg : args) {
-            if (scriptFilename.isEmpty() && arg.endsWith(".py")) {
+            if (scriptFilename==null && arg.endsWith(".py")) {
                 scriptFilename = arg;
                 jythonArgs.add(arg);
             } else if ("--cli-debug".equals(arg)) {


### PR DESCRIPTION
@jeff5 ,  please urgently merge this pull request.

With the latest changes, args after the .py filename are ignored. In the example below, the `asciidoc.java` filename is ignored and not passed to the jbang-deps.py script.

```
$ jbang run jython-cli@jython --cli-debug jbang-deps.py asciidoc.java
[jbang.cmd, run, --java, 21, --main, org.python.util.jython, org.python:jython-slim:2.7.4, jbang-deps.py]
Traceback (most recent call last):
  File "jbang-deps.py", line 8, in <module>
    file = sys.argv[1]
IndexError: index out of range: 1
```

The fix is simple; I just removed a `break` statement allowing the `args` loop to process all the command-line parameters.

With the fix applied, order is restored.

```
jbang run JythonCli.java --cli-debug jbang-deps.py asciidoc.java
[jbang.cmd, run, --java, 21, --main, org.python.util.jython, org.python:jython-slim:2.7.4, jbang-deps.py, asciidoc.java]
Checking newest versions of GAV (1)
* org.asciidoctor:asciidoctorj:jar:3.0.0 is up to date
Checking newest versions of GAV (1)
* org.asciidoctor:asciidoctorj-diagram:jar:2.3.1 -> 3.0.1
Checking newest versions of GAV (1)
* org.asciidoctor:asciidoctorj-diagram-plantuml:jar:1.2025.2 -> 1.2025.3
```

*jbang-deps.py*

```python
import os
import sys
import json

def versions(dep):
   os.system("jbang toolbox@maveniverse versions " + dep)

file = sys.argv[1]
os.system("jbang info tools %s > jbang-deps.json"%(file))

d = json.load(open("jbang-deps.json"))

for dep in d["dependencies"]:
   versions(dep)
```

*asciidoc.java*

```java
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS org.asciidoctor:asciidoctorj:3.0.0
//DEPS org.asciidoctor:asciidoctorj-diagram:2.3.1
//DEPS org.asciidoctor:asciidoctorj-diagram-plantuml:1.2025.2

import org.asciidoctor.Asciidoctor;
import org.asciidoctor.Options;
import org.asciidoctor.SafeMode;

import java.io.File;

public class asciidoc {

    public static void main(String[] args) {
        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
        asciidoctor.requireLibrary("asciidoctor-diagram");
        asciidoctor.convertFile(
                new File(args[0]),
                Options.builder()
                        .toFile(true)
                        .safe(SafeMode.UNSAFE)
                        .build());
    }
}
```