### PR TITLE
Added command alias cli

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,5 +1,9 @@
 {
   "aliases": {
+    "cli": {
+      "script-ref": "JythonCli.java",
+      "description": "Run Jython 2.7"
+    },
     "jython-cli": {
       "script-ref": "JythonCli.java",
       "description": "Run Jython 2.7"


### PR DESCRIPTION
See #17 

`jbang run cli@jython ....` is more concise than `jbang run jython-cli@jython ...`