### PR TITLE
Replaced JBang --option value with --option=value

### DIFF
--- a/JythonCli.java
+++ b/JythonCli.java
@@ -210,21 +210,17 @@ public class JythonCli {
         cmd.add("jbang" + (windows ? ".cmd" : ""));
         cmd.add("run");
 
-        cmd.add("--java");
-        cmd.add(javaVersion);
+        cmd.add("--java=" + javaVersion);
 
         for (String ropt : ropts) {
-            cmd.add("--runtime-option");
-            cmd.add(ropt);
+            cmd.add("-R=" + ropt);
         }
 
         for (String dep : deps) {
-            cmd.add("--deps");
-            cmd.add(dep);
+            cmd.add("--deps=" + dep);
         }
 
-        cmd.add("--main");
-        cmd.add("org.python.util.jython");
+        cmd.add("--main=org.python.util.jython");
 
         cmd.add("org.python:jython-slim:" + jythonVersion);
 


### PR DESCRIPTION
JBang versions after 0.138.0 do not support the previously "not officially supported but working anyway" way of specifying runtime options that JythonCli.java uses for readability purposes.

No longer can we specify options using the following syntax:

* `--runtime-option  -Dpython.console.encoding=UTF-8`

The `--<option>=<value>` format must be used. The format changes to:

* `--runtime-option=-Dpython.console.encoding=UTF-8`

which can be  shortened to :

* `-R=-Dpython.console.encoding=UTF-8`

The same update has been applied to options `--deps` and `--main`.